### PR TITLE
fixed:

### DIFF
--- a/bootstrap-fluid.tmpl
+++ b/bootstrap-fluid.tmpl
@@ -79,6 +79,8 @@
     <div id="wikileft" class="span3">
       <div class="well sidebar-nav">
         <!--wiki:{$Group}.SideBar {$SiteGroup}.SideBar-->
+        <hr/>
+		<!--wiki:{$Group}.SiteNav {$SiteGroup}.SiteNav --> <!-- we could also place it in the top header... -->
       </div><!--/.well -->
     </div><!--/span-->
     <!--/PageLeftFmt-->

--- a/css/pmwiki.css
+++ b/css/pmwiki.css
@@ -13,10 +13,23 @@
  * here.
  */
 
-body {
-    padding-top: 60px;
+@media (max-width: 979px) {
+	body {
+		padding-top: 0px;
+	}
+	
+	.pull-right { 
+		position:relative;
+		float: right;
+		z-index:10;
+	} 
 }
 
+@media (min-width: 980px) {
+	body {
+		padding-top: 60px;
+	}
+}
 .container, .container-fluid {
     margin-right: auto;
     margin-left: auto;


### PR DESCRIPTION
- extra top padding space in the nav bar
- menu covering the search field when the menu is expanded on narrow screen

I don't know if it's a good practice to include responsive stuff in the pmwiki.css, but this way it will prevent to add the extra padding at the top of the page when the screen is below 980 px. I prefered to add this in the pmwiki files, because I guess the bootstrap things could be more easily updated this way.
For the menu covering the seach form, it's working now but it could look better.
